### PR TITLE
Invalid syntax error due to match-case statement for older Python versions

### DIFF
--- a/ubiq_security_fpe/ffx.py
+++ b/ubiq_security_fpe/ffx.py
@@ -17,13 +17,12 @@ class Context:
         self.key = key
 
         self.alg = None
-        match len(key):
-            case 16:
-                self.alg = 'aes_128_cbc'
-            case 24:
-                self.alg = 'aes_192_cbc'
-            case 32:
-                self.alg = 'aes_256_cbc'
+        if len(key) == 16:
+            self.alg = 'aes_128_cbc'
+        elif len(key) == 24:
+            self.alg = 'aes_192_cbc'
+        elif len(key) == 32:
+            self.alg = 'aes_256_cbc'
         if self.alg == None:
             raise RuntimeError('Key length invalid.')
 


### PR DESCRIPTION
With these changes, invalid syntax error can be avoided when using a python version < 3.10. Currently using 3.9.16 and was encountering invalid syntax error due to the usage of match-case statement.

**Ubiq Version**
2.1.1

